### PR TITLE
Update HandController.cs to avoid creating multiple instances of HandRuntimeControl which causes memory leaks

### DIFF
--- a/Assets/Vox/Hands/Runtime/HandController.cs
+++ b/Assets/Vox/Hands/Runtime/HandController.cs
@@ -28,7 +28,9 @@ namespace Vox.Hands
             set
             {
                 m_handType = value;
-                InitializeRuntimeControl();
+                if(m_runtimeControl == null){
+                    InitializeRuntimeControl();
+                }
             }
         }
 
@@ -143,6 +145,7 @@ namespace Vox.Hands
 
         public void InitializeRuntimeControl()
         {
+            if (m_runtimeControl != null) return;
             var animator = GetComponent<Animator>();
             m_avatar = animator.avatar;
 


### PR DESCRIPTION
Thanks for the awesome work @hiroki-o ❤️

# Overview
When compiled to an iOS project and run using XCode and Instruments, there is a huge amount of memory leaks pointing to HandRuntimeControl being created again and again
![image](https://user-images.githubusercontent.com/12766318/197139763-08bb2ac6-3c6d-4240-83f1-7b6fb2f20cf7.png)
![img_v2_54967fb9-cb73-46b7-b801-f4afda862d4g](https://user-images.githubusercontent.com/12766318/197138840-7409860f-3e28-4181-975c-682508e36208.jpg)

# What is changed
- added checks on the initialization of HandRuntimeControl, if it has been created, avoid recreating it again